### PR TITLE
Implements mutable merge algorithm

### DIFF
--- a/Sources/Algorithms/Merge.swift
+++ b/Sources/Algorithms/Merge.swift
@@ -1,0 +1,230 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// merge(at:by:) / merge(subrange:at:by:)
+//===----------------------------------------------------------------------===//
+
+extension MutableCollection where Self: BidirectionalCollection {
+  public mutating func merge(
+    at middle: Index,
+    by areInAscendingOrder: (Element, Element) throws -> Bool
+  ) rethrows {
+    try merge(subrange: startIndex..<endIndex, at: middle, by: areInAscendingOrder)
+  }
+  
+  public mutating func merge(
+    subrange: Range<Index>,
+    at middle: Index,
+    by areInAscendingOrder: (Element, Element) throws -> Bool
+  ) rethrows {
+    if subrange.lowerBound == middle || subrange.upperBound == middle { return }
+    
+    let lowerBound = distance(from: startIndex, to: subrange.lowerBound)
+    let rangeCount = distance(from: subrange.lowerBound, to: subrange.upperBound)
+    let lowerCount = distance(from: subrange.lowerBound, to: middle)
+    
+    // FIXME: Insertion sort for small counts?
+    
+    let result: Void? = try withContiguousMutableStorageIfAvailable
+    { selfBuffer -> Void in
+      let upperCount = rangeCount - lowerCount
+      let upperBound = lowerBound + rangeCount
+      let endOfLower = lowerBound + lowerCount
+      
+      try withUnsafeTemporaryAllocation(
+        of: Element.self, capacity: Swift.min(lowerCount, upperCount)
+      ) { tempBuffer in
+        if lowerCount < upperCount {
+          // Merge into lower section from start of tempBuffer and upper section,
+          // prioritizing tempBuffer values
+          
+          // Move elements from lower section to temporary buffer
+          _ = tempBuffer.moveInitialize(
+            fromContentsOf: selfBuffer[lowerBound..<endOfLower])
+          
+          var firstUninitialized = selfBuffer.baseAddress! + lowerBound
+          var tempSource = tempBuffer.baseAddress!
+          let tempUpper = tempSource + tempBuffer.count
+          var selfSource = selfBuffer.baseAddress! + endOfLower
+          let selfUpper = selfBuffer.baseAddress! + upperBound
+          
+          func finalize() {
+            if tempSource < tempUpper {
+              firstUninitialized.moveInitialize(
+                from: tempSource,
+                count: tempUpper - tempSource)
+            }
+          }
+          
+          do {
+            while tempSource < tempUpper && selfSource < selfUpper {
+              if try areInAscendingOrder(selfSource.pointee, tempSource.pointee) {
+                firstUninitialized.moveInitialize(from: selfSource, count: 1)
+                selfSource += 1
+              } else {
+                firstUninitialized.moveInitialize(from: tempSource, count: 1)
+                tempSource += 1
+              }
+              firstUninitialized += 1
+            }
+          } catch {
+            finalize()
+            throw error
+          }
+          
+          finalize()
+        } else {
+          // Merge (backwards) into upper section from end of tempBuffer and lower,
+          // prioritizing tempBuffer values
+          _ = tempBuffer.moveInitialize(
+            fromContentsOf: selfBuffer[endOfLower..<upperBound])
+          
+          var lastUninitialized = selfBuffer.baseAddress! + upperBound - 1
+          var tempSource = (tempBuffer.baseAddress! + tempBuffer.count) - 1
+          let tempLowerBound = tempBuffer.baseAddress!
+          var selfSource = (selfBuffer.baseAddress! + endOfLower) - 1
+          let selfLowerBound = selfBuffer.baseAddress! + lowerBound
+          
+          while tempSource >= tempLowerBound && selfSource >= selfLowerBound {
+            // FIXME: Figure out throwing situation
+            if try !areInAscendingOrder(tempSource.pointee, selfSource.pointee) {
+              lastUninitialized.moveInitialize(from: tempSource, count: 1)
+              if tempSource == tempLowerBound {
+                break
+              }
+              tempSource -= 1
+              assert(tempSource >= tempLowerBound)
+            } else {
+              lastUninitialized.moveInitialize(from: selfSource, count: 1)
+              if selfSource == selfLowerBound {
+                // Done moving from the lower section, but there could still
+                // be elements in the temp buffer.
+                
+                // Note: `tempSource` points to the last element in the temp
+                // buffer, not the "past the end" position, hence the +1 here:
+                let tempCount = (tempSource + 1) - tempLowerBound
+                selfLowerBound.moveInitialize(from: tempLowerBound, count: tempCount)
+                break
+              }
+              selfSource -= 1
+              assert(selfSource >= selfLowerBound)
+            }
+            lastUninitialized -= 1
+            assert(lastUninitialized >= selfLowerBound)
+          }
+        }
+      }
+    }
+    
+    if result == nil {
+      try mergeInPlace(subrange: subrange, at: middle, by: areInAscendingOrder)
+    }
+  }
+}
+
+extension MutableCollection where Self: BidirectionalCollection, Element: Comparable {
+  public mutating func merge(at middle: Index) {
+    merge(at: middle, by: <)
+  }
+  
+  public mutating func merge(subrange: Range<Index>, at middle: Index) {
+    merge(subrange: subrange, at: middle, by: <)
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// mergeInPlace(at:by:) / mergeInPlace(subrange:at:by:)
+//===----------------------------------------------------------------------===//
+
+extension MutableCollection where Self: BidirectionalCollection {
+  public mutating func mergeInPlace(
+    at middle: Index,
+    by areInAscendingOrder: (Element, Element) throws -> Bool
+  ) rethrows {
+    try mergeInPlace(subrange: startIndex..<endIndex, at: middle, by: areInAscendingOrder)
+  }
+  
+  public mutating func mergeInPlace(
+    subrange: Range<Index>,
+    at middle: Index,
+    by areInAscendingOrder: (Element, Element) throws -> Bool
+  ) rethrows {
+    // If either side of `middle` is empty, there's no work to do.
+    if subrange.lowerBound == middle || middle == subrange.upperBound {
+      return
+    }
+    
+    let lowerCount = distance(from: subrange.lowerBound, to: middle)
+    let upperCount = distance(from: middle, to: subrange.upperBound)
+    // FIXME: Insertion sort for small counts?
+    guard lowerCount + upperCount > 2 else {
+      if try areInAscendingOrder(self[middle], self[subrange.lowerBound]) {
+        swapAt(subrange.lowerBound, middle)
+      }
+      return
+    }
+    
+    let lowerPivot: Index
+    let upperPivot: Index
+
+    if lowerCount < upperCount {
+      // a a b b c c d e f|a b b b c d d d e e e e e f f
+      //               ^                 ^
+      //           lowerPivot        upperPivot
+      // (lower pivot must be strictly greater than element at upper)
+      // after rotation:
+      // a a b b c c d|a b b b c d d/e f|d e e e e e f f
+      //                             ^
+      //                         newMiddle
+      upperPivot = index(middle, offsetBy: upperCount / 2)
+      // FIXME: Binary search instead of linear? Require random access?
+      lowerPivot = try self[subrange.lowerBound..<middle].startOfSuffix(
+        while: { try areInAscendingOrder(self[upperPivot], $0) })
+    } else {
+      // a b b b c d d d e e e e e f f|a a b b c c d e f
+      //             ^                             ^
+      //         lowerPivot                    upperPivot
+      // (upper pivot must be first element equal or greater than lower)
+      // after rotation:
+      // a b b b c d|a a b b c c/d d e e e e e f f|d e f
+      //                        ^
+      //                    newMiddle
+      lowerPivot = index(subrange.lowerBound, offsetBy: lowerCount / 2)
+      // FIXME: Binary search instead of linear? Require random access?
+      upperPivot = try self[middle..<subrange.upperBound].endOfPrefix(
+        while: { try areInAscendingOrder($0, self[lowerPivot]) })
+    }
+
+    let newMiddle = self.rotate(subrange: lowerPivot..<upperPivot, toStartAt: middle)
+    try self.mergeInPlace(
+      subrange: subrange.lowerBound..<newMiddle,
+      at: lowerPivot,
+      by: areInAscendingOrder)
+    try self.mergeInPlace(
+      subrange: newMiddle..<subrange.upperBound,
+      at: upperPivot,
+      by: areInAscendingOrder)
+  }
+}
+
+extension MutableCollection where Self: BidirectionalCollection, Element: Comparable {
+  public mutating func mergeInPlace(at middle: Index) {
+    mergeInPlace(at: middle, by: <)
+  }
+  
+  public mutating func mergeInPlace(
+    subrange: Range<Index>,
+    at middle: Index
+  ) {
+    mergeInPlace(subrange: subrange, at: middle, by: <)
+  }
+}

--- a/Tests/SwiftAlgorithmsTests/COWLoggingArray.swift
+++ b/Tests/SwiftAlgorithmsTests/COWLoggingArray.swift
@@ -1,0 +1,133 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+fileprivate var COWLoggingArray_CopyCount = 0
+
+public func AssertNoCopyOnWrite<T>(
+  _ elements: some Sequence<T>,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #file,
+  line: UInt = #line,
+  _ body: (inout COWLoggingArray<T>) -> Void
+) {
+  let copyCountBeforeBody = COWLoggingArray_CopyCount
+  var loggingArray = COWLoggingArray(elements)
+  body(&loggingArray)
+  XCTAssertEqual(
+    copyCountBeforeBody,
+    COWLoggingArray_CopyCount,
+    message(), file: file, line: line)
+}
+
+public struct COWLoggingArray<Element> {
+  var storage: Storage
+  
+  class Storage {
+    var buffer: UnsafeMutableBufferPointer<Element>
+    var count: Int
+    var capacity: Int {
+      buffer.count
+    }
+    
+    init(capacity: Int) {
+      self.buffer = .allocate(capacity: capacity)
+      self.count = 0
+    }
+    
+    deinit {
+      buffer.baseAddress!.deinitialize(count: count)
+      buffer.deallocate()
+    }
+    
+    func cloned(capacity: Int? = nil) -> Storage {
+      let newCapacity = Swift.max(capacity ?? self.capacity, self.capacity)
+      let newStorage = Storage(capacity: newCapacity)
+      newStorage.buffer.baseAddress!
+        .initialize(from: buffer.baseAddress!, count: count)
+      newStorage.count = count
+      return newStorage
+    }
+  }
+  
+  mutating func _makeUnique() {
+    if !isKnownUniquelyReferenced(&storage) {
+      storage = storage.cloned()
+      COWLoggingArray_CopyCount += 1
+    }
+  }
+}
+
+extension COWLoggingArray: RandomAccessCollection, RangeReplaceableCollection,
+  MutableCollection, ExpressibleByArrayLiteral
+{
+  public var count: Int { storage.count }
+  public var startIndex: Int { 0 }
+  public var endIndex: Int { count }
+  
+  public subscript(i: Int) -> Element {
+    get {
+      storage.buffer[i]
+    }
+    set {
+      _makeUnique()
+      storage.buffer[i] = newValue
+    }
+  }
+  
+  public init() {
+    storage = Storage(capacity: 10)
+  }
+  
+  public mutating func reserveCapacity(_ n: Int) {
+    if !isKnownUniquelyReferenced(&storage) {
+      COWLoggingArray_CopyCount += 1
+      storage = storage.cloned(capacity: n)
+    } else if count < n {
+      storage = storage.cloned(capacity: n)
+    }
+  }
+  
+  public mutating func replaceSubrange<C>(_ subrange: Range<Int>, with newElements: C)
+    where C : Collection, Element == C.Element
+  {
+    _makeUnique()
+    let newCount = (count - subrange.count) + newElements.count
+    if newCount > storage.capacity {
+      storage = storage.cloned(capacity: newCount)
+    }
+    
+    let startOfSubrange = storage.buffer.baseAddress! + subrange.lowerBound
+    let endOfSubrange = startOfSubrange + subrange.count
+    let endOfNewElements = startOfSubrange + newElements.count
+    let countAfterSubrange = count - subrange.upperBound
+    
+    // clear out old elements
+    startOfSubrange.deinitialize(count: subrange.count)
+    
+    // move elements above subrange
+    endOfNewElements.moveInitialize(from: endOfSubrange, count: countAfterSubrange)
+    
+    // assign new elements
+    for (pointer, element) in zip(startOfSubrange..., newElements) {
+      pointer.initialize(to: element)
+    }
+    
+    // update count
+    storage.count = newCount
+  }
+  
+  public init(arrayLiteral elements: Element...) {
+    storage = Storage(capacity: elements.count)
+    replaceSubrange(0..<0, with: elements)
+  }
+}

--- a/Tests/SwiftAlgorithmsTests/MergeTests.swift
+++ b/Tests/SwiftAlgorithmsTests/MergeTests.swift
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import Algorithms
+
+
+final class MergeTests: XCTestCase {
+  func _createInput(seed: UInt64, count: Int) -> (input: [Int], pivot: Int) {
+    var rng = SplitMix64(seed: seed)
+    // Create array of numbers with two sorted partitions
+    var numbers = (1...count).map { _ in Int.random(in: 1...10, using: &rng) }
+    let pivot = Int.random(in: 0...numbers.count, using: &rng)
+    numbers[..<pivot].sort()
+    numbers[pivot...].sort()
+    
+    return (numbers, pivot)
+  }
+  
+  func _runMergeTest(_ input: [Int], pivot: Int) {
+    var numbers = input
+    
+    // Various copies for testing different merge strategies
+    var inPlace = numbers
+    var partial = numbers
+    var partialInPlace = numbers
+    var positional = Array(numbers.enumerated())
+    var positionalInPlace = positional
+
+    // Merge with extra storage & in-place, verify equal
+    numbers.merge(at: pivot)
+    XCTAssertTrue(numbers.isSorted())
+    inPlace.mergeInPlace(at: pivot)
+    XCTAssertEqualSequences(numbers, inPlace)
+
+    // Merge subsequences with extra storage & in-place, verify expected
+    let subrange = min(pivot, 5) ..< max(pivot, partial.count - 5)
+    partial.merge(subrange: subrange, at: pivot, by: <)
+    XCTAssertTrue(partial[subrange].isSorted(by: <))
+    partialInPlace.mergeInPlace(subrange: subrange, at: pivot, by: <)
+    XCTAssertEqualSequences(partial, partialInPlace)
+
+    // Check merge stability
+    positional.merge(at: pivot, by: { $0.element < $1.element })
+    XCTAssertTrue(positional.isSorted(by: { ($0.element, $0.offset) < ($1.element, $1.offset) }))
+    XCTAssertEqualSequences(numbers, positional.map { $0.element })
+    positionalInPlace.mergeInPlace(at: pivot, by: { $0.element < $1.element })
+    XCTAssert(positional.elementsEqual(positionalInPlace, by: ==))
+  }
+
+  func testMerge() {
+    var empty: [Int] = []
+    empty.merge(at: 0, by: <)
+    empty.mergeInPlace(at: 0, by: <)
+
+    let range = 1...100
+    var numbers = Array(range)
+    for i in 0...numbers.count {
+      numbers.merge(at: i, by: <)
+      XCTAssertEqualSequences(numbers, range)
+      numbers.mergeInPlace(at: i, by: <)
+      XCTAssertEqualSequences(numbers, range)
+    }
+    
+    // Nonsense shouldn't crash or get stuck
+    var nonsense = range.map { _ in Int.random(in: 1...10) }
+    nonsense.merge(at: nonsense.count / 3, by: <)
+    nonsense.mergeInPlace(at: nonsense.count / 3, by: <)
+  }
+  
+  func testFuzzMerge() {
+    for _ in 0..<100 {
+      let seed: UInt64 = UInt64.random(in: 0 ... .max)
+      let (input, pivot) = _createInput(seed: seed, count: 300)
+      _runMergeTest(input, pivot: pivot)
+    }
+  }
+  
+  func testMergeCopyOnWrite() {
+    var numbers = (1...100).shuffled()
+    let pivot = 25
+    numbers[..<pivot].sort()
+    numbers[pivot...].sort()
+    
+    AssertNoCopyOnWrite(numbers) { array in
+      array.mergeInPlace(at: pivot, by: <)
+    }
+  }
+}


### PR DESCRIPTION
This change implements mutable merge algorithms, both in place and using a temporary buffer. The temporary buffer is only used if the mutable collection supports accessing its storage as a contiguous unsafe buffer; if not, the in-place merge is used instead.

<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
