### PR TITLE
Add a `joined` method with prefix/suffix

### DIFF
--- a/Sources/Algorithms/Joined.swift
+++ b/Sources/Algorithms/Joined.swift
@@ -487,3 +487,13 @@ extension LazySequenceProtocol where Elements: Collection, Element: Collection {
     JoinedByClosureCollection(base: elements, separator: separator)
   }
 }
+
+extension Sequence where Element: Collection, Element.SubSequence == Substring {
+  public func joined(separator: Element, prefix: Element, suffix: Element) -> String {
+    var result = ""
+    result.append(contentsOf: prefix[...])
+    result.append(contentsOf: self.joined(separator: separator[...]))
+    result.append(contentsOf: suffix[...])
+    return result
+  }
+}

--- a/Tests/SwiftAlgorithmsTests/JoinedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/JoinedTests.swift
@@ -129,4 +129,53 @@ final class JoinedTests: XCTestCase {
       validator2.validate(strings.lazy.joined(by: { _, _ in separator }))
     }
   }
+  
+  func testJoinedPrefixSuffix() {
+    let input = [
+        [5,3,0, 0,7,0, 0,0,0],
+        [6,0,0, 1,9,5, 0,0,0],
+        [0,9,8, 0,0,0, 0,6,0],
+      
+        [8,0,0, 0,6,0, 0,0,3],
+        [4,0,0, 8,0,3, 0,0,1],
+        [7,0,0, 0,2,0, 0,0,6],
+          
+        [0,6,0, 0,0,0, 2,8,0],
+        [0,0,0, 4,1,9, 0,0,5],
+        [0,0,0, 0,8,0, 0,7,9],
+    ]
+
+    func prettyString(_ sudoku: [[Int]]) -> String {
+      sudoku.chunks(ofCount: 3).map { (bigChunk: ArraySlice<[Int]>) -> String in
+           bigChunk.map { (row: [Int]) -> String in
+             row.chunks(ofCount: 3).map { (smallChunk: ArraySlice<Int>) -> String in
+               smallChunk.lazy.map(String.init).joined(separator: " ", prefix: " ", suffix: " ")
+                }.joined(separator: "|", prefix: "|", suffix: "|")
+            }.joined(separator: "\n")
+        }.joined(
+          separator: "\n+-------+-------+-------+\n",
+          prefix: "+-------+-------+-------+\n",
+          suffix: "\n+-------+-------+-------+")
+    }
+    
+    let output = prettyString(input)
+    XCTAssertEqual(
+      output,
+      """
+        +-------+-------+-------+
+        | 5 3 0 | 0 7 0 | 0 0 0 |
+        | 6 0 0 | 1 9 5 | 0 0 0 |
+        | 0 9 8 | 0 0 0 | 0 6 0 |
+        +-------+-------+-------+
+        | 8 0 0 | 0 6 0 | 0 0 3 |
+        | 4 0 0 | 8 0 3 | 0 0 1 |
+        | 7 0 0 | 0 2 0 | 0 0 6 |
+        +-------+-------+-------+
+        | 0 6 0 | 0 0 0 | 2 8 0 |
+        | 0 0 0 | 4 1 9 | 0 0 5 |
+        | 0 0 0 | 0 8 0 | 0 7 9 |
+        +-------+-------+-------+
+        """
+    )
+  }
 }


### PR DESCRIPTION
Joining with a prefix and suffix is a relatively common operation that isn't terribly simple to implement concisely. This adds that operation for joining strings.

Related to #195.

<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
