### PR TITLE
Migrate to typed errors across the board

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift Algorithms open source project
@@ -11,6 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 import PackageDescription
+
+let availabilityDefinition = PackageDescription.SwiftSetting.unsafeFlags([
+    "-Xfrontend",
+    "-define-availability",
+    "-Xfrontend",
+    "SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0",
+])
 
 let package = Package(
     name: "swift-algorithms",
@@ -27,7 +34,8 @@ let package = Package(
             name: "Algorithms",
             dependencies: [
               .product(name: "RealModule", package: "swift-numerics"),
-            ]),
+            ],
+            swiftSettings: [availabilityDefinition]),
         .testTarget(
             name: "SwiftAlgorithmsTests",
             dependencies: ["Algorithms"]),

--- a/Sources/Algorithms/Chunked.swift
+++ b/Sources/Algorithms/Chunked.swift
@@ -456,9 +456,9 @@ extension Collection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of this collection.
   @inlinable
-  public func chunked(
-    by belongInSameGroup: (Element, Element) throws -> Bool
-  ) rethrows -> [SubSequence] {
+  public func chunked<E: Error>(
+    by belongInSameGroup: (Element, Element) throws(E) -> Bool
+  ) throws(E) -> [SubSequence] {
     guard !isEmpty else { return [] }
     var result: [SubSequence] = []
     
@@ -489,9 +489,9 @@ extension Collection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of this collection.
   @inlinable
-  public func chunked<Subject: Equatable>(
-    on projection: (Element) throws -> Subject
-  ) rethrows -> [(Subject, SubSequence)] {
+  public func chunked<Subject: Equatable, E: Error>(
+    on projection: (Element) throws(E) -> Subject
+  ) throws(E) -> [(Subject, SubSequence)] {
     guard !isEmpty else { return [] }
     var result: [(Subject, SubSequence)] = []
     

--- a/Sources/Algorithms/FirstNonNil.swift
+++ b/Sources/Algorithms/FirstNonNil.swift
@@ -31,9 +31,9 @@ extension Sequence {
   /// - Complexity: O(*n*), where *n* is the number of elements at the start of
   ///   the sequence that result in `nil` when applying the transformation.
   @inlinable
-  public func firstNonNil<Result>(
-    _ transform: (Element) throws -> Result?
-  ) rethrows -> Result? {
+  public func firstNonNil<Result, E: Error>(
+    _ transform: (Element) throws(E) -> Result?
+  ) throws(E) -> Result? {
     for value in self {
       if let value = try transform(value) {
         return value

--- a/Sources/Algorithms/Grouped.swift
+++ b/Sources/Algorithms/Grouped.swift
@@ -19,7 +19,15 @@ extension Sequence {
   /// - Returns: A dictionary containing grouped elements of self, keyed by
   ///     the keys derived by the `keyForValue` closure.
   @inlinable
-  public func grouped<GroupKey>(by keyForValue: (Element) throws -> GroupKey) rethrows -> [GroupKey: [Element]] {
-    try Dictionary(grouping: self, by: keyForValue)
+  public func grouped<GroupKey, E: Error>(
+    by keyForValue: (Element) throws(E) -> GroupKey
+  ) throws(E) -> [GroupKey: [Element]] {
+    do {
+      // This stdlib Dictionary initializer doesn't use typed errors,
+      // so we need to catch and cast any thrown error to our expected type.
+      return try Dictionary(grouping: self, by: keyForValue)
+    } catch {
+      throw error as! E
+    }
   }
 }

--- a/Sources/Algorithms/Keyed.swift
+++ b/Sources/Algorithms/Keyed.swift
@@ -19,10 +19,13 @@ extension Sequence {
   /// - Parameters:
   ///   - keyForValue: A closure that returns a key for each element in `self`.
   @inlinable
-  public func keyed<Key>(
-    by keyForValue: (Element) throws -> Key
-  ) rethrows -> [Key: Element] {
-    return try self.keyed(by: keyForValue, resolvingConflictsWith: { _, old, new in new })
+  public func keyed<Key, E: Error>(
+    by keyForValue: (Element) throws(E) -> Key
+  ) throws(E) -> [Key: Element] {
+    // An anonymous closure is inferred as `throws(any Error)`, so we give it
+    // the correct type here.
+    let resolve: (Key, Element, Element) throws(E) -> Element = { _, _, new in new }
+    return try self.keyed(by: keyForValue, resolvingConflictsWith: resolve)
   }
 
   /// Creates a new Dictionary from the elements of `self`, keyed by the
@@ -39,10 +42,10 @@ extension Sequence {
   ///     keys that are encountered. The closure returns the desired value for
   ///     the final dictionary.
   @inlinable
-  public func keyed<Key>(
-    by keyForValue: (Element) throws -> Key,
-    resolvingConflictsWith resolve: (Key, Element, Element) throws -> Element
-  ) rethrows -> [Key: Element] {
+  public func keyed<Key, E: Error>(
+    by keyForValue: (Element) throws(E) -> Key,
+    resolvingConflictsWith resolve: (Key, Element, Element) throws(E) -> Element
+  ) throws(E) -> [Key: Element] {
     var result = [Key: Element]()
 
     for element in self {

--- a/Sources/Algorithms/Reductions.swift
+++ b/Sources/Algorithms/Reductions.swift
@@ -112,13 +112,16 @@ extension Sequence {
   ///
   /// - Complexity: O(_n_), where _n_ is the length of the sequence.
   @inlinable
-  public func reductions<Result>(
+  public func reductions<Result, E: Error>(
     _ initial: Result,
-    _ transform: (Result, Element) throws -> Result
-  ) rethrows -> [Result] {
-    try reductions(into: initial) { result, element in
+    _ transform: (Result, Element) throws(E) -> Result
+  ) throws(E) -> [Result] {
+    // An anonymous closure is inferred as `throws(any Error)`, so we give it
+    // the correct type here.
+    let reducer: (inout Result, Element) throws(E) -> Void = { result, element in
       result = try transform(result, element)
     }
+    return try reductions(into: initial, reducer)
   }
 
   /// Returns an array containing the accumulated results of combining the
@@ -156,11 +159,10 @@ extension Sequence {
   ///
   /// - Complexity: O(_n_), where _n_ is the length of the sequence.
   @inlinable
-  public func reductions<Result>(
+  public func reductions<Result, E: Error>(
     into initial: Result,
-    _ transform: (inout Result, Element) throws -> Void
-  ) rethrows -> [Result] {
-
+    _ transform: (inout Result, Element) throws(E) -> Void
+  ) throws(E) -> [Result] {
     var output = [Result]()
     output.reserveCapacity(underestimatedCount + 1)
     output.append(initial)
@@ -415,9 +417,9 @@ extension Sequence {
   ///
   /// - Complexity: O(_n_), where _n_ is the length of the sequence.
   @inlinable
-  public func reductions(
-    _ transform: (Element, Element) throws -> Element
-  ) rethrows -> [Element] {
+  public func reductions<E: Error>(
+    _ transform: (Element, Element) throws(E) -> Element
+  ) throws(E) -> [Element] {
     var iterator = makeIterator()
     guard let initial = iterator.next() else { return [] }
     return try IteratorSequence(iterator).reductions(initial, transform)
@@ -582,19 +584,19 @@ extension LazySequenceProtocol {
 extension Sequence {
   @available(*, deprecated, message: "Use reductions(_:_:) instead.")
   @inlinable
-  public func scan<Result>(
+  public func scan<Result, E: Error>(
     _ initial: Result,
-    _ transform: (Result, Element) throws -> Result
-  ) rethrows -> [Result] {
+    _ transform: (Result, Element) throws(E) -> Result
+  ) throws(E) -> [Result] {
     try reductions(initial, transform)
   }
 
   @available(*, deprecated, message: "Use reductions(into:_:) instead.")
   @inlinable
-  public func scan<Result>(
+  public func scan<Result, E: Error>(
     into initial: Result,
-    _ transform: (inout Result, Element) throws -> Void
-  ) rethrows -> [Result] {
+    _ transform: (inout Result, Element) throws(E) -> Void
+  ) throws(E) -> [Result] {
     try reductions(into: initial, transform)
   }
 }
@@ -612,9 +614,9 @@ extension LazySequenceProtocol {
 extension Sequence {
   @available(*, deprecated, message: "Use reductions(_:) instead.")
   @inlinable
-  public func scan(
-    _ transform: (Element, Element) throws -> Element
-  ) rethrows -> [Element] {
+  public func scan<E: Error>(
+    _ transform: (Element, Element) throws(E) -> Element
+  ) throws(E) -> [Element] {
     try reductions(transform)
   }
 }

--- a/Sources/Algorithms/Suffix.swift
+++ b/Sources/Algorithms/Suffix.swift
@@ -24,9 +24,9 @@ extension BidirectionalCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  public func suffix(
-    while predicate: (Element) throws -> Bool
-  ) rethrows -> SubSequence {
+  public func suffix<E: Error>(
+    while predicate: (Element) throws(E) -> Bool
+  ) throws(E) -> SubSequence {
     try self[startOfSuffix(while: predicate)...]
   }
 }
@@ -46,11 +46,11 @@ extension Collection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  public func endOfPrefix(
-    while predicate: (Element) throws -> Bool
-  ) rethrows -> Index {
+  public func endOfPrefix<E: Error>(
+    while predicate: (Element) throws(E) -> Bool
+  ) throws(E) -> Index {
     var index = startIndex
-    while try index != endIndex && predicate(self[index]) {
+    while index != endIndex, try predicate(self[index]) {
       formIndex(after: &index)
     }
     return index
@@ -72,9 +72,9 @@ extension BidirectionalCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable
-  public func startOfSuffix(
-    while predicate: (Element) throws -> Bool
-  ) rethrows -> Index {
+  public func startOfSuffix<E: Error>(
+    while predicate: (Element) throws(E) -> Bool
+  ) throws(E) -> Index {
     var index = endIndex
     while index != startIndex {
       let after = index

--- a/Sources/Algorithms/Trim.swift
+++ b/Sources/Algorithms/Trim.swift
@@ -26,11 +26,10 @@ extension Collection {
   ///   omitted from the resulting slice.
   ///
   /// - Complexity: O(*n*), where *n* is the length of this collection.
-  ///
   @inlinable
-  public func trimmingPrefix(
-    while predicate: (Element) throws -> Bool
-  ) rethrows -> SubSequence {
+  public func trimmingPrefix<E: Error>(
+    while predicate: (Element) throws(E) -> Bool
+  ) throws(E) -> SubSequence {
     let start = try endOfPrefix(while: predicate)
     return self[start..<endIndex]
   }
@@ -55,12 +54,11 @@ extension Collection where Self: RangeReplaceableCollection {
   ///   removed from the string.
   ///
   /// - Complexity: O(*n*), where *n* is the length of this collection.
-  ///
   @inlinable
   @_disfavoredOverload
-  public mutating func trimPrefix(
-    while predicate: (Element) throws -> Bool
-  ) rethrows {
+  public mutating func trimPrefix<E: Error>(
+    while predicate: (Element) throws(E) -> Bool
+  ) throws(E) {
     let startOfResult = try endOfPrefix(while: predicate)
     removeSubrange(startIndex..<startOfResult)
   }
@@ -81,12 +79,12 @@ extension Collection where Self == Self.SubSequence {
   ///   be removed from the string.
   ///
   /// - Complexity: O(*n*), where *n* is the length of this collection.
-  ///
   @inlinable
-  public mutating func trimPrefix(
-    while predicate: (Element) throws -> Bool
-  ) rethrows {
-    self = try trimmingPrefix(while: predicate)
+  public mutating func trimPrefix<E: Error>(
+    while predicate: (Element) throws(E) -> Bool
+  ) throws(E) {
+    let start = try endOfPrefix(while: predicate)
+    self = self[start..<endIndex]
   }
 }
 
@@ -108,12 +106,12 @@ extension BidirectionalCollection {
   ///   omitted from the resulting slice.
   ///
   /// - Complexity: O(*n*), where *n* is the length of this collection.
-  ///
   @inlinable
-  public func trimming(
-    while predicate: (Element) throws -> Bool
-  ) rethrows -> SubSequence {
-    try trimmingPrefix(while: predicate).trimmingSuffix(while: predicate)
+  public func trimming<E: Error>(
+    while predicate: (Element) throws(E) -> Bool
+  ) throws(E) -> SubSequence {
+    let start = try endOfPrefix(while: predicate)
+    return try self[start..<endIndex].trimmingSuffix(while: predicate)
   }
   
   /// Returns a `SubSequence` formed by discarding all elements at the end of
@@ -129,11 +127,10 @@ extension BidirectionalCollection {
   ///   omitted from the resulting slice.
   ///
   /// - Complexity: O(*n*), where *n* is the length of this collection.
-  ///
   @inlinable
-  public func trimmingSuffix(
-    while predicate: (Element) throws -> Bool
-  ) rethrows -> SubSequence {
+  public func trimmingSuffix<E: Error>(
+    while predicate: (Element) throws(E) -> Bool
+  ) throws(E) -> SubSequence {
     let end = try startOfSuffix(while: predicate)
     return self[startIndex..<end]
   }
@@ -158,14 +155,14 @@ extension BidirectionalCollection where Self: RangeReplaceableCollection {
   ///   removed from the string.
   ///
   /// - Complexity: O(*n*), where *n* is the length of this collection.
-  ///
   @inlinable
   @_disfavoredOverload
-  public mutating func trim(
-    while predicate: (Element) throws -> Bool
-  ) rethrows {
+  public mutating func trim<E: Error>(
+    while predicate: (Element) throws(E) -> Bool
+  ) throws(E) {
+    let start = try endOfPrefix(while: predicate)
+    self.removeSubrange(startIndex..<start)
     try trimSuffix(while: predicate)
-    try trimPrefix(while: predicate)
   }
   
   /// Mutates a `BidirectionalCollection` by discarding all elements at the end
@@ -182,12 +179,11 @@ extension BidirectionalCollection where Self: RangeReplaceableCollection {
   ///   removed from the string.
   ///
   /// - Complexity: O(*n*), where *n* is the length of this collection.
-  ///
   @inlinable
   @_disfavoredOverload
-  public mutating func trimSuffix(
-    while predicate: (Element) throws -> Bool
-  ) rethrows {
+  public mutating func trimSuffix<E: Error>(
+    while predicate: (Element) throws(E) -> Bool
+  ) throws(E) {
     let endOfResult = try startOfSuffix(while: predicate)
     removeSubrange(endOfResult..<endIndex)
   }
@@ -208,11 +204,10 @@ extension BidirectionalCollection where Self == Self.SubSequence {
   ///   removed from the string.
   ///
   /// - Complexity: O(*n*), where *n* is the length of this collection.
-  ///
   @inlinable
-  public mutating func trim(
-    while predicate: (Element) throws -> Bool
-  ) rethrows {
+  public mutating func trim<E: Error>(
+    while predicate: (Element) throws(E) -> Bool
+  ) throws(E) {
     self = try trimming(while: predicate)
   }
 
@@ -230,11 +225,10 @@ extension BidirectionalCollection where Self == Self.SubSequence {
   ///   removed from the string.
   ///
   /// - Complexity: O(*n*), where *n* is the length of this collection.
-  ///
   @inlinable
-  public mutating func trimSuffix(
-    while predicate: (Element) throws -> Bool
-  ) rethrows {
+  public mutating func trimSuffix<E: Error>(
+    while predicate: (Element) throws(E) -> Bool
+  ) throws(E) {
     self = try trimmingSuffix(while: predicate)
   }
 }

--- a/Sources/Algorithms/Unique.swift
+++ b/Sources/Algorithms/Unique.swift
@@ -112,9 +112,9 @@ extension Sequence {
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
   @inlinable
-  public func uniqued<Subject: Hashable>(
-    on projection: (Element) throws -> Subject
-  ) rethrows -> [Element] {
+  public func uniqued<Subject: Hashable, E: Error>(
+    on projection: (Element) throws(E) -> Subject
+  ) throws(E) -> [Element] {
     var seen: Set<Subject> = []
     var result: [Element] = []
     for element in self {

--- a/Tests/SwiftAlgorithmsTests/GroupedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/GroupedTests.swift
@@ -13,7 +13,7 @@ import XCTest
 import Algorithms
 
 final class GroupedTests: XCTestCase {
-  private class SampleError: Error {}
+  private final class SampleError: Error {}
 
   // Based on https://github.com/apple/swift/blob/4d1d8a9de5ebc132a17aee9fc267461facf89bf8/validation-test/stdlib/Dictionary.swift#L1974-L1988
 

--- a/Tests/SwiftAlgorithmsTests/KeyedTests.swift
+++ b/Tests/SwiftAlgorithmsTests/KeyedTests.swift
@@ -13,7 +13,7 @@ import XCTest
 import Algorithms
 
 final class KeyedTests: XCTestCase {
-  private class SampleError: Error {}
+  private final class SampleError: Error {}
 
   func testUniqueKeys() {
     let d = ["Apple", "Banana", "Cherry"].keyed(by: { $0.first! })

--- a/Tests/SwiftAlgorithmsTests/TrimTests.swift
+++ b/Tests/SwiftAlgorithmsTests/TrimTests.swift
@@ -75,9 +75,10 @@ final class TrimTests: XCTestCase {
   }
   
   // Self == Self.Subsequence
-  func testTrimPrefixNoAmbiguity() {
+  func testTrimPrefixNoAmbiguity() throws {
     var values = [2, 10, 12, 15, 20, 100] as ArraySlice
-    values.trimPrefix { $0.isMultiple(of: 2) }
+    // FIXME: `trimPrefix` in the _StringProcessing module always `throws`
+    try values.trimPrefix { $0.isMultiple(of: 2) }
     XCTAssertEqual(values, [15, 20, 100])
   }
   


### PR DESCRIPTION
Along with converting to typed errors, this also bumps the swiftlang version in Package.swift to 6.0 (to support typed errors).

<!--
    Thanks for contributing to Swift Algorithms!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](../blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary
